### PR TITLE
Fix shareable config delegate visibility

### DIFF
--- a/uwb_qorvo_demo/ViewController.swift
+++ b/uwb_qorvo_demo/ViewController.swift
@@ -134,7 +134,7 @@ class ViewController: UIViewController, NISessionDelegate {
     }
 
     // Called when iOS generates its shareable configuration for the accessory
-    private func session(_ session: NISession,
+    func session(_ session: NISession,
                  didGenerateShareableConfigurationData shareableConfigurationData: Data,
                  for bluetoothPeerIdentifier: UUID) {
         print("▶︎ ViewController: Received shareable configuration (\(shareableConfigurationData.count) bytes) for \(bluetoothPeerIdentifier)")


### PR DESCRIPTION
## Summary
- remove `private` from `session(_:didGenerateShareableConfigurationData:for:)` so it can be called by `NISession`

## Testing
- `xcodebuild test -project uwb_qorvo_demo.xcodeproj -scheme uwb_qorvo_demo -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68433924075c8332bdf7f0cd325d1097